### PR TITLE
Add ids as a function alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ It's not so smart right now, but here's a cheatsheet:
 | `:count`                                                               | `COUNT(*)`
 | `:count_column1`, `:column1_count`                                     | `COUNT(column1)` (doesn't count NULL's in that column)
 | `:count_distinct_column1`, `:column1_distinct_count`                   | `COUNT(DISTINCT column1)`
+| `:ids`                                                                 | `ARRAY_AGG(id)` (only works on Postgres)
 | `:max_column1`, `:column1_max`, `:maximum_column1`, `:column1_maximum` | `MAX(column1)`
 | `:min_column1`, `:column1_min`, `:minimum_column1`, `:column1_minimum` | `MIN(column1)`
 | `:avg_column1`, `:column1_avg`, `:average_column1`, `:column1_average` | `AVG(column1)`

--- a/lib/calculate-all/helpers.rb
+++ b/lib/calculate-all/helpers.rb
@@ -22,6 +22,8 @@ module CalculateAll
             "MAX(#{$1})"
           when /^(.*)_minimum$/, /^minimum_(.*)$/
             "MIN(#{$1})"
+          when :ids
+            'ARRAY_AGG(id)'
           else
             raise ArgumentError, "Can't recognize function alias #{key}"
           end

--- a/test/calculate_all_postgresql_test.rb
+++ b/test/calculate_all_postgresql_test.rb
@@ -28,4 +28,13 @@ class CalculateAllPostgresqlTest < Minitest::Test
     assert_equal expected, Order.group(:kind).calculate_all('ARRAY_AGG(currency ORDER BY id)')
   end
 
+  def test_ids_aggregation
+    create_orders
+    expected = {
+      'RUB' => Order.where(currency: 'RUB').ids,
+      'USD' => Order.where(currency: 'USD').ids
+    }
+    assert_equal(expected, Order.group(:currency).calculate_all(:ids))
+  end
+
 end


### PR DESCRIPTION
Hi there, I found myself fetching the associated ids during a call during my project multiple times. I performed this by calling
```ruby
Order.group(:currency).calculate_all(ids: 'ARRAY_AGG(id)')
```
I've now added the `:ids` as a function alias but the `ARRAY_AGG` function only works on Postgres.

On MySQL sort of similar behaviour can be achieved by using the [group-concat](https://dev.mysql.com/doc/refman/5.7/en/group-by-functions.html#function_group-concat) function but it returns a string instead of an array. This can later be parsed but I did not put too much effort in this since I don't use MySQL. In addition you would need a check in the helpers module to see what database service you are using. Maybe someone has an idea and we can have a discussion about this.