### PR TITLE
Added support for Groupdate 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Order.calculate_all(:count, :max_price, &OpenStruct.method(:new))
 calculate-all should work with [groupdate](https://github.com/ankane/groupdate) too:
 
 ```ruby
-Order.group_by_year(:created_at, last: 5, default_value: {}).calculate_all(:price_min, :price_max)
+Order.group_by_year(:created_at, last: 5).calculate_all(:price_min, :price_max)
 => {
   Sun, 01 Jan 2012 => {},
   Tue, 01 Jan 2013 => {},

--- a/lib/calculate-all.rb
+++ b/lib/calculate-all.rb
@@ -71,6 +71,11 @@ module CalculateAll
       results[key] = value
     end
 
+    if defined?(Groupdate.process_result)
+      default_value = return_plain_values ? nil : {}
+      results = Groupdate.process_result(self, results, default_value: default_value)
+    end
+
     # Return the output array
     results
   end

--- a/test/calculate_all_common.rb
+++ b/test/calculate_all_common.rb
@@ -107,7 +107,7 @@ module CalculateAllCommon
       ['cash', Date.new(2014,1,1)] => { count: 1, sum_cents: 300 },
       ['cash', Date.new(2015,1,1)] => { count: 2, sum_cents: 900 }
     }
-    assert_equal expected, Order.group(:kind).group_by_year(:created_at, default_value: {}).calculate_all(:count, :sum_cents)
+    assert_equal expected, Order.group(:kind).group_by_year(:created_at).calculate_all(:count, :sum_cents)
   end
 
   def test_value_wrapping_one_expression_and_no_groups


### PR DESCRIPTION
Hey @codesnik, this adds support for Groupdate 4 (and makes the existing tests pass). I use a similar approach in the ActiveMedian gem. https://github.com/ankane/active_median/blob/8d8313a35117643c60c317c54a0b831457cf0547/lib/active_median/model.rb#L54

Without this, calculate-all returns times instead of dates in keys. This also fills in missing data points.