### PR TITLE
Add Configuration For Plain Value Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Add options of configuration of `plain_values` in a matter of consistency 
+
 ## 0.1.1
 
 * groupdate compatibility

--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ Order.group_by_year(:created_at, last: 5, default_value: {}).calculate_all(:pric
 }
 ```
 
+## Configuration
+
+You can change the behavior of plain values and force to get the function returned
+
+```
+CalculateAll.configure do |config|
+  config.plain_values = false # default true
+end
+```
+
+Return `[{ cash: { count: 3 }}] instead of [{ cash: 3 }]`
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/calculate-all.rb
+++ b/lib/calculate-all.rb
@@ -8,7 +8,7 @@ module CalculateAll
 
     # If only one function_alias is given, the result can be just a single value
     # So return [{ cash: 3 }] instead of [{ cash: { count: 3 }}]
-    if function_aliases.size == 1 && functions == {}
+    if configuration.plain_values && (function_aliases.size == 1 && functions == {})
       return_plain_values = true
     end
 
@@ -73,6 +73,22 @@ module CalculateAll
 
     # Return the output array
     results
+  end
+  
+  class << self
+    attr_writer :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
   end
 end
 

--- a/lib/calculate-all.rb
+++ b/lib/calculate-all.rb
@@ -1,6 +1,7 @@
 require 'calculate-all/version'
 require 'calculate-all/helpers'
 require 'calculate-all/querying'
+require 'calculate-all/configuration'
 
 module CalculateAll
   # Method to aggregate function results in one request
@@ -8,7 +9,7 @@ module CalculateAll
 
     # If only one function_alias is given, the result can be just a single value
     # So return [{ cash: 3 }] instead of [{ cash: { count: 3 }}]
-    if configuration.plain_values && (function_aliases.size == 1 && functions == {})
+    if CalculateAll.configuration.plain_values && (function_aliases.size == 1 && functions == {})
       return_plain_values = true
     end
 

--- a/lib/calculate-all/configuration.rb
+++ b/lib/calculate-all/configuration.rb
@@ -1,0 +1,9 @@
+module CalculateAll
+  class Configuration
+    attr_accessor :plain_values
+
+    def initialize
+      @plain_values = true
+    end
+  end
+end

--- a/lib/calculate-all/version.rb
+++ b/lib/calculate-all/version.rb
@@ -1,3 +1,3 @@
 module CalculateAll
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
Add configuration options for `plain_values` in a matter of consistency 

## Configuration

You can change the behaviour of plain values and force to get the function returned

```
CalculateAll.configure do |config|
  config.plain_values = false # default true
end
```

Return `[{ cash: { count: 3 }}] instead of [{ cash: 3 }]`