### PR TITLE
Change how single expression shortcut like :sum_col1 is processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Allow expression shortcuts as attribute values too for renaming
 * Allow grouping expressions to be returned in values too
+* Breaking change: only one *string* expression is returned unwrapped in a hash.
+  Single expression shortcut like `:count` will be expanded to `{count: value}` rows.
 
 ## 0.2.2
 

--- a/lib/calculate-all.rb
+++ b/lib/calculate-all.rb
@@ -4,9 +4,10 @@ require "calculate-all/version"
 module CalculateAll
   # Calculates multiple aggregate values on a scope in one request, similarly to #calculate
   def calculate_all(*expression_shortcuts, **named_expressions, &block)
-    # If only one aggregate is given without explicit naming,
+    # If only one aggregate is given as a string or Arel.sql without explicit naming,
     # return row(s) directly without wrapping in Hash
-    if expression_shortcuts.size == 1 && named_expressions.size == 0
+    if expression_shortcuts.size == 1 && expression_shortcuts.first.is_a?(String) &&
+        named_expressions.size == 0
       return_plain_values = true
     end
 


### PR DESCRIPTION
It will return hash {sum_col1: 123} and not just 123 for consistensy of result structure.
All existing shortcuts with groups are trivially calculated with existing active_record methods and are not worth keeping.